### PR TITLE
make main process wait on the mpv child process

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> Result<()> {
             dbg!(res);
         }
     } else {
-        spwan_command(res, &config).spawn()?;
+        spwan_command(res, &config).spawn()?.wait()?;
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,19 @@ use b2m::*;
 #[cfg(feature = "fina")]
 use parsers::fina::Fina;
 use parsers::lux::Lux;
+#[cfg(not(windows))]
 use std::os::unix::process::CommandExt;
+
+#[cfg(windows)]
+fn exec_command(mut command: std::process::Command) {
+    command.spawn().expect("failed to execute command")
+        .wait().expect("failed to wait on child process");
+}
+
+#[cfg(not(windows))]
+fn exec_command(mut command: std::process::Command) {
+    command.exec();
+}
 
 fn main() -> Result<()> {
     let matches = cli::b2m().get_matches();
@@ -26,12 +38,7 @@ fn main() -> Result<()> {
             dbg!(res);
         }
     } else {
-        let mut command = spwan_command(res, &config);
-        if cfg!(windows) {
-            command.spawn()?.wait()?;
-        } else {
-            command.exec();
-        }
+        exec_command(spwan_command(res, &config));
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use b2m::*;
 #[cfg(feature = "fina")]
 use parsers::fina::Fina;
 use parsers::lux::Lux;
+use std::os::unix::process::CommandExt;
 
 fn main() -> Result<()> {
     let matches = cli::b2m().get_matches();
@@ -25,7 +26,12 @@ fn main() -> Result<()> {
             dbg!(res);
         }
     } else {
-        spwan_command(res, &config).spawn()?.wait()?;
+        let mut command = spwan_command(res, &config);
+        if cfg!(windows) {
+            command.spawn()?.wait()?;
+        } else {
+            command.exec();
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
On Windows, wait on the mpv child process. On Unix, replace the main process with the mpv process to reduce resource usage.
This enables the user to use <kbd>Ctrl</kbd>+<kbd>C</kbd> to stop mpv, and also avoids zombie processes.